### PR TITLE
Add Uniswap V4 direct swap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <p>
 This is a smart contract that performs swaps
-by directly interacting withUniswap V2 and V3 
-liquidity pools.
+by directly interacting with Uniswap V2, V3 and V4
+liquidity pools. It also exposes quote helpers (`quoteV2`, `quoteV3`, `quoteV4`) for estimating swap outputs without executing trades.
 </p>
 
 <p>

--- a/contracts/DirectSwap.sol
+++ b/contracts/DirectSwap.sol
@@ -3,14 +3,16 @@
 pragma solidity ^0.8.30;
 
 import {UniswapV2DirectSwapper} from "./libs/SwapV2.sol";
-import{UniswapV3DirectSwapper} from "./libs/SwapV3.sol";
+import {UniswapV3DirectSwapper} from "./libs/SwapV3.sol";
+import {UniswapV4DirectSwapper} from "./libs/SwapV4.sol";
+import {IUniswapV4PoolManager} from "./libs/Interfaces.sol";
 
 
 /*
 * @dev Perform swaps on uniswap v3 and v3 by interacting directly with the liquidity pools, rather than the swap router.
 */
 
-contract UniswapDirectSwap is UniswapV2DirectSwapper, UniswapV3DirectSwapper {
+contract UniswapDirectSwap is UniswapV2DirectSwapper, UniswapV3DirectSwapper, UniswapV4DirectSwapper {
     address public immutable weth;
     uint256 private nonce;
     bytes32 internal constant ACCESS_GRANTED_SIG = 0xdeb5c31899474fe8c086c95ff9344480d19365676a6a1d22d37bb8e3e7c0ef18;
@@ -167,6 +169,24 @@ contract UniswapDirectSwap is UniswapV2DirectSwapper, UniswapV3DirectSwapper {
 
         (poolUsed, amountOut) = super._swapV2(tokenIn, tokenOut, amountIn,  slippageBps, true, true);
         emit SwapExecuted(evaluateSwapResults(tokenIn, tokenOut, amountIn, amountOut, false), false, amountOut);
+    }
+
+    function swapV4(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint24 fee,
+        int24 tickSpacing,
+        uint32 slippageBps
+    )
+        external
+        payable
+        auth
+        override
+        returns (IUniswapV4PoolManager.PoolKey memory key, uint256 amountOut)
+    {
+        (key, amountOut) = super._swapV4(tokenIn, tokenOut, amountIn, fee, tickSpacing, slippageBps, true, true);
+        emit SwapExecuted(evaluateSwapResults(tokenIn, tokenOut, amountIn, amountOut, true), true, amountOut);
     }
 
     /*

--- a/contracts/libs/DeploymentAddresses.sol
+++ b/contracts/libs/DeploymentAddresses.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.26;
 
-
-
 struct Deployment {
     uint256 cid;
     address uniswapV2Router;
@@ -10,6 +8,8 @@ struct Deployment {
     address uniswapV3Router;
     address uniswapV3Factory;
     address uniswapV3Quoter;
+    address uniswapV4Factory;
+    address uniswapV4PoolManager;
     address wrappedEther;
     address nativeEther;
 
@@ -35,6 +35,8 @@ contract DeploymentAddresses {
             deployment.uniswapV3Router= 0x2626664c2603336E57B271c5C0b26F421741e481;
             deployment.uniswapV3Factory = 0x33128a8fC17869897dcE68Ed026d694621f6FDfD;
             deployment.uniswapV3Quoter = 0x222cA98F00eD15B1faE10B61c277703a194cf5d2; // view quoter
+            deployment.uniswapV4Factory = address(0);
+            deployment.uniswapV4PoolManager = address(0);
             deployment.wrappedEther = 0x4200000000000000000000000000000000000006;
 
         } else {

--- a/contracts/libs/Interfaces.sol
+++ b/contracts/libs/Interfaces.sol
@@ -45,3 +45,28 @@ interface IUniswapV3Pool {
         bytes calldata data
     ) external returns (int256 amount0, int256 amount1);
 }
+
+interface IUniswapV4PoolManager {
+    struct PoolKey {
+        address currency0;
+        address currency1;
+        uint24 fee;
+        int24 tickSpacing;
+        address hook;
+    }
+
+    struct SwapParams {
+        PoolKey key;
+        bool zeroForOne;
+        int256 amountSpecified;
+        uint160 sqrtPriceLimitX96;
+        bytes hookData;
+    }
+
+    struct BalanceDelta {
+        int256 amount0;
+        int256 amount1;
+    }
+
+    function swap(SwapParams calldata params) external returns (BalanceDelta memory delta);
+}

--- a/contracts/libs/SwapV4.sol
+++ b/contracts/libs/SwapV4.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DeploymentAddresses} from "./DeploymentAddresses.sol";
+import {TransferHelper} from "./TransferHelper.sol";
+import {IWETH, IUniswapV4PoolManager} from "./Interfaces.sol";
+
+abstract contract UniswapV4DirectSwapper is DeploymentAddresses, TransferHelper {
+    address private immutable poolManager;
+    address private immutable wrappedEther;
+    uint160 private constant MIN_SQRT_RATIO = 4295128739 + 1;
+    uint160 private constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970341 - 1;
+
+    error AmountMismatch(uint256 msgValue, uint256 amountIn);
+    error QuoteCallFailed();
+
+    constructor() {
+        poolManager = deployment.uniswapV4PoolManager;
+        wrappedEther = deployment.wrappedEther;
+    }
+
+    function swapV4(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint24 fee,
+        int24 tickSpacing,
+        uint32 slippageBps
+    )
+        external
+        payable
+        virtual
+        returns (IUniswapV4PoolManager.PoolKey memory key, uint256 amountOut)
+    {
+        return _swapV4(tokenIn, tokenOut, amountIn, fee, tickSpacing, slippageBps, true, true);
+    }
+
+    function _swapV4(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint24 fee,
+        int24 tickSpacing,
+        uint32 slippageBps,
+        bool pullIn,
+        bool pushOut
+    )
+        internal
+        returns (IUniswapV4PoolManager.PoolKey memory key, uint256 amountOut)
+    {
+        require(poolManager != address(0), "pool manager not set");
+
+        (address currency0, address currency1) = tokenIn < tokenOut
+            ? (tokenIn, tokenOut)
+            : (tokenOut, tokenIn);
+        bool zeroForOne = tokenIn == currency0;
+
+        key = IUniswapV4PoolManager.PoolKey({
+            currency0: currency0,
+            currency1: currency1,
+            fee: fee,
+            tickSpacing: tickSpacing,
+            hook: address(0)
+        });
+
+        if (tokenIn == wrappedEther && msg.value > 0) {
+            if (msg.value != amountIn) revert AmountMismatch(msg.value, amountIn);
+            IWETH(wrappedEther).deposit{value: msg.value}();
+        } else {
+            if (pullIn) {
+                if (tokenAllowance(tokenIn, msg.sender, address(this)) < amountIn) {
+                    revert InsufficientAllowance(tokenIn, msg.sender, amountIn);
+                }
+                safeTransferFrom(tokenIn, msg.sender, address(this), amountIn);
+            }
+        }
+
+        safeApprove(tokenIn, poolManager, amountIn);
+
+        uint256 balBefore = tokenBalance(tokenOut, address(this));
+
+        IUniswapV4PoolManager.SwapParams memory params = IUniswapV4PoolManager.SwapParams({
+            key: key,
+            zeroForOne: zeroForOne,
+            amountSpecified: int256(amountIn),
+            sqrtPriceLimitX96: zeroForOne ? MIN_SQRT_RATIO : MAX_SQRT_RATIO,
+            hookData: new bytes(0)
+        });
+
+        IUniswapV4PoolManager.BalanceDelta memory delta =
+            IUniswapV4PoolManager(poolManager).swap(params);
+
+        if (delta.amount0 > 0) {
+            safeTransfer(tokenIn, poolManager, uint256(delta.amount0));
+        } else if (delta.amount1 > 0) {
+            safeTransfer(tokenIn, poolManager, uint256(delta.amount1));
+        }
+
+        amountOut = tokenBalance(tokenOut, address(this)) - balBefore;
+
+        if (slippageBps > 0) {
+            uint256 minAmountOut = (amountIn * (10000 - slippageBps)) / 10000;
+            if (amountOut < minAmountOut) revert SlippageExceeded(amountOut, minAmountOut);
+        }
+
+        if (pushOut) {
+            if (tokenOut == wrappedEther) {
+                IWETH(wrappedEther).withdraw(amountOut);
+                executeCall(msg.sender, amountOut, new bytes(0));
+            } else {
+                safeTransfer(tokenOut, msg.sender, amountOut);
+            }
+        }
+    }
+
+    function quoteV4(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint24 fee,
+        int24 tickSpacing
+    ) external view returns (uint256 amountOut) {
+        (address currency0, address currency1) = tokenIn < tokenOut
+            ? (tokenIn, tokenOut)
+            : (tokenOut, tokenIn);
+        bool zeroForOne = tokenIn == currency0;
+
+        IUniswapV4PoolManager.PoolKey memory key = IUniswapV4PoolManager.PoolKey({
+            currency0: currency0,
+            currency1: currency1,
+            fee: fee,
+            tickSpacing: tickSpacing,
+            hook: address(0)
+        });
+
+        IUniswapV4PoolManager.SwapParams memory params = IUniswapV4PoolManager.SwapParams({
+            key: key,
+            zeroForOne: zeroForOne,
+            amountSpecified: int256(amountIn),
+            sqrtPriceLimitX96: zeroForOne ? MIN_SQRT_RATIO : MAX_SQRT_RATIO,
+            hookData: new bytes(0)
+        });
+
+        bytes memory payload = abi.encodeWithSelector(
+            IUniswapV4PoolManager.swap.selector,
+            params
+        );
+        (bool ok, bytes memory data) = staticCall(poolManager, payload);
+        if (!ok) revert QuoteCallFailed();
+
+        IUniswapV4PoolManager.BalanceDelta memory delta =
+            abi.decode(data, (IUniswapV4PoolManager.BalanceDelta));
+
+        amountOut = uint256(
+            zeroForOne ? -delta.amount1 : -delta.amount0
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce UniswapV4DirectSwapper library for PoolManager-based swaps
- wire Uniswap V4 into DirectSwap contract and deployment addresses
- document V4 support in README
- provide `quoteV4` helper to estimate swap output amounts

## Testing
- `npm install solc@0.8.30` *(fails: 403 Forbidden - GET https://registry.npmjs.org/solc)*
- `npx solcjs --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/solcjs)*

------
https://chatgpt.com/codex/tasks/task_e_689e0533bcbc8320bc838347398b9169